### PR TITLE
feat(инфра): добавлены Docker, Compose и скрипт для инициализации БД …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,2 @@
-FROM ubuntu:latest
-LABEL authors="mattoyudzuru"
-
-ENTRYPOINT ["top", "-b"]
+FROM postgres:16-alpine
+COPY ddl.sql /docker-entrypoint-initdb.d/

--- a/ddl.sql
+++ b/ddl.sql
@@ -1,0 +1,105 @@
+-- ENUM TYPES
+CREATE TYPE sport AS ENUM ('football', 'boxing', 'basketball', 'chess', 'tennis', 'jiu jitsu');
+CREATE TYPE type_tournament AS ENUM ('solo', 'team');
+CREATE TYPE type_group AS ENUM ('olympic', 'swiss', 'round_robin');
+CREATE TYPE participant_type AS ENUM ('solo', 'team');
+CREATE TYPE registration_status AS ENUM ('pending', 'accepted', 'rejected');
+
+-- USERS
+CREATE TABLE users
+(
+    id              UUID PRIMARY KEY,
+    name            VARCHAR,
+    surname         VARCHAR,
+    patronymic      VARCHAR,
+    phone_number    VARCHAR,
+    email           VARCHAR UNIQUE,
+    hashed_password VARCHAR,
+    is_admin        BOOLEAN,
+    date_of_birth   DATE,
+    age             INT,
+    sex             CHAR(1),
+    weight          FLOAT,
+    height          FLOAT,
+    created_at      TIMESTAMP,
+    bio             TEXT,
+    avatar_url      VARCHAR
+);
+
+-- TEAMS
+CREATE TABLE teams
+(
+    id         UUID PRIMARY KEY,
+    name       VARCHAR,
+    created_at TIMESTAMP,
+    avatar     VARCHAR
+);
+
+-- TEAM-PLAYER RELATION
+CREATE TABLE team_player_relation
+(
+    team_id UUID NOT NULL REFERENCES teams (id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    PRIMARY KEY (team_id, user_id)
+);
+
+-- USER MMR BY SPORT
+CREATE TABLE user_sport_mmr_relation
+(
+    user_id UUID  NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    sport   sport NOT NULL,
+    mmr     DOUBLE PRECISION,
+    PRIMARY KEY (user_id, sport)
+);
+
+-- TEAM MMR
+CREATE TABLE team_mmr_relation
+(
+    team_id UUID PRIMARY KEY REFERENCES teams (id) ON DELETE CASCADE,
+    mmr     DOUBLE PRECISION
+);
+
+-- TOURNAMENTS
+CREATE TABLE tournaments
+(
+    id                    UUID PRIMARY KEY,
+    title                 VARCHAR,
+    description           TEXT,
+    sport                 sport,
+    type_tournament       type_tournament,
+    type_group            type_group,
+    matches_number        INT,
+    start_time            TIMESTAMP,
+    created_at            TIMESTAMP,
+    entry_cost            DECIMAL,
+    max_participants      INT,
+    registration_deadline TIMESTAMP,
+    place                 VARCHAR,
+    organizer_id          UUID REFERENCES users (id)
+);
+
+-- TOURNAMENT REGISTRATIONS
+CREATE TABLE tournament_registrations
+(
+    tournament_id    UUID REFERENCES tournaments (id) ON DELETE CASCADE,
+    sport            sport,
+    participant_id   UUID,
+    participant_type participant_type,
+    registered_at    TIMESTAMP,
+    status           registration_status,
+    PRIMARY KEY (tournament_id, participant_id, participant_type)
+);
+
+-- MATCHES
+CREATE TABLE matches
+(
+    match_id          UUID PRIMARY KEY,
+    started_at        TIMESTAMP,
+    created_at        TIMESTAMP,
+    position          INT,
+    partition1_id     UUID,
+    partition2_id     UUID,
+    partition1_points INT,
+    partition2_points INT,
+    winner_id         UUID
+);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: sports_db
+    restart: always
+    environment:
+      POSTGRES_DB: sports_platform
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5399:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./ddl.sql:/docker-entrypoint-initdb.d/ddl.sql
+
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5048:80"
+
+volumes:
+  db_data:


### PR DESCRIPTION
feat(инфра): добавлена Docker-инфраструктура для локальной разработки

## Описание изменений
- Добавлен Dockerfile для сборки образа приложения
- Добавлен docker-compose.yml с конфигурацией Postgres
- Обновлен .gitignore для Docker-артефактов

## Мотивация и контекст
Изменения позволяют:
- Быстро поднимать локальное окружение
- Гарантировать одинаковые среды у всех разработчиков
- Тестить и локально работать с БД

## Тип изменений
- [x] Фича
- [ ] Багфикc
- [ ] Документация
- [ ] Рефакторинг

#7 